### PR TITLE
Install architecture specific chromium to build for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # FROM node:lts-alpine
-FROM node:lts-buster
+FROM node:18
 WORKDIR /app
 
-RUN apt-get update && apt-get -y install libnss3 libexpat1
+RUN apt-get update && apt-get -y install libnss3 libexpat1 chromium
 
 COPY package.json package-lock.json /app/
 run npm i @sparticuz/chromium
 RUN npm install
 RUN npm install express
 
-COPY app.js index.js utils.js /app/
+COPY run.sh app.js index.js utils.js /app/
 # user nobody
-CMD AWS_LAMBDA_FUNCTION_NAME="turkey" node app.js
+CMD ln -sf /usr/bin/chromium /tmp/chromium && AWS_LAMBDA_FUNCTION_NAME="turkey" node app.js

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+ln -sf /usr/bin/chromium /tmp/chromium
+CMD AWS_LAMBDA_FUNCTION_NAME="turkey" node app.js


### PR DESCRIPTION
## What?

Support for arm64 build. We need to install an architecture specific chromium

## Why?

Support for arm64 container build

## Examples

N/A

## How to test

Build container on linux/macos and test on armd64 and arm64 machines

## Documentation of functionality

N/A

## Limitations


None known

## Alternatives considered

None known

## Open questions

None known

## Additional details or related context

N/A
