### PR TITLE
[Mozilla Branding Removal] Removes Mozilla branding

### DIFF
--- a/.github/workflows/photomnemonic.yml
+++ b/.github/workflows/photomnemonic.yml
@@ -3,7 +3,7 @@ name: photomnemonic
 on:
   push:
     branches:
-    paths-ignore: ["README.md"]
+    paths-ignore: ["README.md", "LICENSE"]
   workflow_dispatch:
 env:
   containerName: photomnemonic

--- a/.github/workflows/photomnemonic.yml
+++ b/.github/workflows/photomnemonic.yml
@@ -10,9 +10,9 @@ env:
 
 jobs:
   turkeyGitops:
-    uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@master
+    uses: Hubs-Foundation/hubs-ops/.github/workflows/turkeyGitops.yml@master
     with:
-      registry: mozillareality
+      registry: hubsfoundation
       push_gcr: true
       # dockerfile: Dockerfile
     secrets:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# FROM node:lts-alpine
-FROM node:lts-buster
+FROM node:lts-bullseye
 WORKDIR /app
 
 RUN apt-get update && apt-get -y install libnss3 libexpat1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-AWS Lambda function for taking screenshots of the web
+A Node.js Express server for taking screenshots of the web.
+(Originally an AWS Lambda function)

--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ async function screenshot(url) {
     }
     catch (e){
       console.log(e)
-    } 
-    await sleep(500)   
+    }
+    await sleep(500)
     }
 
   console.log("Error failed to produce screenshot")
@@ -50,8 +50,7 @@ module.exports.handler = async function handler(event, context, callback) {
   t0 = new Date().getTime()
 
   const queryStringParameters = event.queryStringParameters || {};
-  const { url = "https://www.mozilla.org"} =
-    queryStringParameters;
+  const { url = "https://hubsfoundation.org/" } = queryStringParameters;
 
   if (!(await urlAllowed(url))) {
     return callback(null, { statusCode: 403, body: "forbidden" });
@@ -66,7 +65,7 @@ module.exports.handler = async function handler(event, context, callback) {
   try {
     const result = await screenshot(url);
     // console.log( "screenshot(url) took: ", new Date().getTime()-t0, "ms")
-    
+
     data = result.data;
     console.log( "data.length: ", data.length)
 

--- a/polycosm-publish.sh
+++ b/polycosm-publish.sh
@@ -12,7 +12,7 @@ fi
 if [[ -z "$HUBS_OPS_PATH" ]]; then
   echo -e "To use this deploy script, you need to clone out the hubs-ops repo
 
-git clone git@github.com:mozilla/hubs-ops.git
+git clone https://github.com/Hubs-Foundation/hubs-ops.git
 
 Then set HUBS_OPS_PATH to point to the cloned repo."
   exit 1

--- a/run-serverless.sh
+++ b/run-serverless.sh
@@ -17,7 +17,7 @@ fi
 if [[ -z "$HUBS_OPS_PATH" ]]; then
   echo -e "To use this deploy script, you need to clone out the hubs-ops repo
 
-git clone git@github.com:mozilla/hubs-ops.git
+git clone https://github.com/Hubs-Foundation/hubs-ops.git
 
 Then set HUBS_OPS_PATH to point to the cloned repo."
   exit 1

--- a/template.yaml
+++ b/template.yaml
@@ -6,13 +6,13 @@ Description: >
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: photomnemonic
-    Description: Site screenshotter for Hubs Cloud
-    Author: Mozilla
+    Description: Site screenshotter for Hubs
+    Author: Mozilla (Original Author), Hubs Foundation (Current Maintainer)
     SpdxLicenseId: MPL-2.0
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
     SemanticVersion: 0.2.0
-    SourceCodeUrl: https://github.com/mozilla/photomnemonic
+    SourceCodeUrl: https://github.com/Hubs-Foundation/photomnemonic
 
 Parameters:
   PhotomnemonicRoleArn:

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 const test = require("ava");
-const { urlAllowed } = require("./url-utils");
+const { urlAllowed } = require("./utils");
 
 test("should disallow invalid and internal urls", async t => {
   t.false(await urlAllowed("invalid url"));


### PR DESCRIPTION
## What?
Removes Mozilla branding

## Why?
to make clear who is responsible

## How to test
1. Deploy image to Hubs Instance: `kubectl set image deployment/photomnemonic photomnemonic=dougreeder/photomnemonic:mozilla-branding-removal-2026-01-28-00-57 -n hcce`  then `kubectl rollout status deploy photomnemonic -n hcce`
3. Run `kubectl get pods -n hcce` to get name of new pod
4. Run `kubectl exec -it photomnemonic-999999 -n hcce -- sh`
5. Run `curl -I http://localhost:5000/screenshot/?url=https://example.com/ `, observe that status is 200


## Documentation of functionality
No change in functionality

## Limitations
I also had to update Node.JS, as the previous version is no longer supported.

